### PR TITLE
优化知乎专栏

### DIFF
--- a/src/new-zhihu-style.css
+++ b/src/new-zhihu-style.css
@@ -89,6 +89,17 @@
 
 
 /*知乎专栏页面*/
+.Post-Row-Content {
+    display: flex !important;
+    justify-content: center !important; /* 水平居中 */
+    align-items: center !important;      /* 垂直居中（可选） */
+}
+
+.Post-Row-Content-left {
+    padding-right: 30px !important;
+    box-sizing: border-box !important;
+    float: none !important; /* 移除浮动 */
+}
 .Post-NormalMain .Post-Header {
     width: var(--width-main-column) !important;
 }
@@ -107,6 +118,10 @@
 }
 
 .css-1qyytj7 {
+    display: none;
+}
+
+.Card-AuthorCard {
     display: none;
 }
 
@@ -139,3 +154,6 @@
 .Container {
     max-width: var(--width-main-column) !important;
 }
+
+
+


### PR DESCRIPTION
我对知乎专栏的部分页面进行了简单的调整
![image](https://github.com/user-attachments/assets/fb50695d-d8b9-4d6e-9dd7-cb247748aec6)
这是调整前的版本
![image](https://github.com/user-attachments/assets/10746c8e-fb55-4b95-8a24-3a4c2bd3c29d)
这是调整之后的版本
我将主体内容居中，并且隐藏了关于作者的页面
