### PR TITLE
修复问答页面下banner栏随宽度调整变化导致的错位

### DIFF
--- a/src/new-zhihu-style.css
+++ b/src/new-zhihu-style.css
@@ -19,18 +19,7 @@
 
 /* .Question-sideColumn {} */
 
-.QuestionHeader-content {
-    width: var(--width-container) !important;
-    padding-left: calc((100vw - var(--width-container))/2) !important;
-}
-
-.QuestionHeader-main {
-    width: var(--width-main-column) !important;
-}
-
-.QuestionHeader-footer-inner {
-    width: var(--width-container) !important;
-}
+/* 问答页面banner使用默认宽度，避免内容宽度调节时标题栏错位 */
 
 
 /*搜索结果页面*/


### PR DESCRIPTION
修复问答页面下banner栏随宽度调整变化导致的错位。

无插件情况下的banner栏：

<img width="1280" height="44" alt="image" src="https://github.com/user-attachments/assets/3e8b5a70-65d9-4f7a-a5ca-bc614078aa05" />

目前插件下的banner栏（宽度设置为默认值65）：

<img width="1280" height="84" alt="image" src="https://github.com/user-attachments/assets/a6f499d6-5402-4c87-b282-23d5fb98ec8c" />

可以看到，将banner也加宽后会出现控件错位和按钮跑到页面外的问题。

我认为在banner不必设置宽度变化也能获得良好的阅读体验。这是修改之后的效果：

<img width="2559" height="848" alt="image" src="https://github.com/user-attachments/assets/1488a262-3f71-4ec5-916d-629ad2db1042" />