### PR TITLE
浏览体验优化

### DIFF
--- a/src/new-zhihu-style.css
+++ b/src/new-zhihu-style.css
@@ -17,7 +17,9 @@
     width: var(--width-main-column) !important;
 }
 
-/* .Question-sideColumn {} */
+.Question-sideColumn {
+    display: none !important;
+}
 
 .QuestionHeader-content {
     width: var(--width-container) !important;
@@ -104,10 +106,6 @@
 
 .Post-Row-Content .Post-Row-Content-right {
     display: none;
-}
-
-.Question-sideColumn {
-    display: none !important;
 }
 
 .Post-Row-Content .Post-Row-Content-left {

--- a/src/new-zhihu-style.css
+++ b/src/new-zhihu-style.css
@@ -112,6 +112,36 @@
     width: auto !important;
 }
 
+/* 关于作者 */
+.Card.AuthorCard {
+    display: none !important;
+}
+
+/* 侧栏推荐 */
+div[data-smart-sticky-anchor="true"] {
+    display: none !important;
+}
+
+/* 侧栏推广 */
+.Pc-card.Card {
+    display: none !important;
+}
+
+/* 主栏推广 */
+[class^="pc-article-answer"],
+[class*=" pc-article-answer"] {
+    display: none !important;
+}
+
+/* “关于知乎”脚注 */
+[role^="contentinfo"] {
+    display: none;
+}
+
+/* 右下角登录浮窗 */
+.css-woosw9 {
+    display: none;
+}
 
 /*回答内容和文章内容*/
 .origin_image {

--- a/src/new-zhihu-style.css
+++ b/src/new-zhihu-style.css
@@ -106,8 +106,8 @@
     display: none;
 }
 
-.css-1qyytj7 {
-    display: none;
+.Question-sideColumn {
+    display: none !important;
 }
 
 .Post-Row-Content .Post-Row-Content-left {


### PR DESCRIPTION
优化控件，提升浏览体验

- 隐藏专栏页面的关于作者控件，侧栏推荐；
- 隐藏所有页面的主栏/侧栏推广、“关于知乎”脚注和未登录时的右下角登录浮窗
- 把隐藏css-1qyytj7(侧栏)的代码，改为禁用其母控件Question-sideColumn，并移动到合适的位置，提高可读性